### PR TITLE
Fix 'body-parser deprecated' msg

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ dotenv.config();
 
 // Updated Code
 app.use(express.json());
-app.use(express.urlencoded());
+app.use(express.urlencoded({ extended: true }));
 app.use(cors());
 
 // The Custom Defined Routes


### PR DESCRIPTION
Minor fix of 'body-parser deprecated' error message on `index.js`